### PR TITLE
Feature code style tools

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,9 +1,20 @@
 [flake8]
 exclude =
     .git,
+    .gitignore
+    .pre-commit-config.yaml
+    .readthedocs.yaml
+    CONTRIBUTING.md
+    LICENSE.md
+    poetry.lock
+    pyproject.toml
+    README.md
+    requirements.txt
     __pycache__,
     notebooks,
     docs,
-ignore = E203, E266, E501, W503, F403, F401
+    tests/aux_search.py
+
+ignore = E203, E266, E501, W503, F403, F401, W605
 max-line-length = 88
 max-complexity = 18

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,9 @@
+[flake8]
+exclude =
+    .git,
+    __pycache__,
+    notebooks,
+    docs,
+ignore = E203, E266, E501, W503, F403, F401
+max-line-length = 88
+max-complexity = 18

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@ Pipfile*
 comments.txt
 timing.py
 *__pycache__*
-poetry.lock
 dist
 tests/aux*
 notebooks/tmp

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,9 @@
 repos:
 -   repo: https://github.com/ambv/black
-    rev: stable
+    rev: 22.1.0
     hooks:
     - id: black # use pyproject.toml to config
 -   repo: https://github.com/pycqa/flake8
-    rev: stable
+    rev: 4.0.1
     hooks:
-    - id: flake8  # use .flake8 file to config.
+    - id: flake8  # use .flake8 file to config

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+-   repo: https://github.com/ambv/black
+    rev: stable
+    hooks:
+    - id: black # use pyproject.toml to config
+-   repo: https://github.com/pycqa/flake8
+    rev: stable
+    hooks:
+    - id: flake8  # use .flake8 file to config.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -182,7 +182,7 @@ The Poetry shell that spawns after calling `poetry shell` also allows you to run
 
 ### Configure local development tools
 
-If you peek into the `pyproject.toml` file you might notice that we are listing several Python packages as development dependencies. We use Python packages such as **flake8**, **black** and **precommit** to speed up our development workflow while making improvements in code quality. flake8 is a linter that checks for code styleguide compliance, black is a formatter that formats your code according to a predefined guideline and precommit is a tool that allows you to run these two automatically each time you make a commit.
+If you peek into the `pyproject.toml` file you might notice that we are listing several Python packages as development dependencies. We use Python packages such as **flake8**, **black** and **pre-commit** to speed up our development workflow while making improvements in code quality. flake8 is a linter that checks for code styleguide compliance, black is a formatter that formats your code according to a predefined guideline and pre-commit is a tool that allows you to run these two automatically each time you make a commit.
 
 **It is highly suggested that you as a contributor use these tools while developing locally.** We automatically check for code styleguide compliance in our CI/CD pipeline. Therefore, using these tools while developing will help you contribute to the PyEuropeana project in a better way.
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,0 +1,264 @@
+[[package]]
+name = "certifi"
+version = "2021.10.8"
+description = "Python package for providing Mozilla's CA Bundle."
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "charset-normalizer"
+version = "2.0.12"
+description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
+category = "main"
+optional = false
+python-versions = ">=3.5.0"
+
+[package.extras]
+unicode_backport = ["unicodedata2"]
+
+[[package]]
+name = "fire"
+version = "0.4.0"
+description = "A library for automatically generating command line interfaces."
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+six = "*"
+termcolor = "*"
+
+[[package]]
+name = "idna"
+version = "3.3"
+description = "Internationalized Domain Names in Applications (IDNA)"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[[package]]
+name = "numpy"
+version = "1.21.5"
+description = "NumPy is the fundamental package for array computing with Python."
+category = "main"
+optional = false
+python-versions = ">=3.7,<3.11"
+
+[[package]]
+name = "numpy"
+version = "1.22.2"
+description = "NumPy is the fundamental package for array computing with Python."
+category = "main"
+optional = false
+python-versions = ">=3.8"
+
+[[package]]
+name = "pandas"
+version = "1.3.5"
+description = "Powerful data structures for data analysis, time series, and statistics"
+category = "main"
+optional = false
+python-versions = ">=3.7.1"
+
+[package.dependencies]
+numpy = [
+    {version = ">=1.17.3", markers = "platform_machine != \"aarch64\" and platform_machine != \"arm64\" and python_version < \"3.10\""},
+    {version = ">=1.19.2", markers = "platform_machine == \"aarch64\" and python_version < \"3.10\""},
+    {version = ">=1.20.0", markers = "platform_machine == \"arm64\" and python_version < \"3.10\""},
+    {version = ">=1.21.0", markers = "python_version >= \"3.10\""},
+]
+python-dateutil = ">=2.7.3"
+pytz = ">=2017.3"
+
+[package.extras]
+test = ["hypothesis (>=3.58)", "pytest (>=6.0)", "pytest-xdist"]
+
+[[package]]
+name = "python-dateutil"
+version = "2.8.2"
+description = "Extensions to the standard Python datetime module"
+category = "main"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+
+[package.dependencies]
+six = ">=1.5"
+
+[[package]]
+name = "pytz"
+version = "2021.3"
+description = "World timezone definitions, modern and historical"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "requests"
+version = "2.27.1"
+description = "Python HTTP for Humans."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
+
+[package.dependencies]
+certifi = ">=2017.4.17"
+charset-normalizer = {version = ">=2.0.0,<2.1.0", markers = "python_version >= \"3\""}
+idna = {version = ">=2.5,<4", markers = "python_version >= \"3\""}
+urllib3 = ">=1.21.1,<1.27"
+
+[package.extras]
+socks = ["PySocks (>=1.5.6,!=1.5.7)", "win-inet-pton"]
+use_chardet_on_py3 = ["chardet (>=3.0.2,<5)"]
+
+[[package]]
+name = "six"
+version = "1.16.0"
+description = "Python 2 and 3 compatibility utilities"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+
+[[package]]
+name = "termcolor"
+version = "1.1.0"
+description = "ANSII Color formatting for output in terminal."
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "urllib3"
+version = "1.26.8"
+description = "HTTP library with thread-safe connection pooling, file post, and more."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
+
+[package.extras]
+brotli = ["brotlipy (>=0.6.0)"]
+secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
+socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
+
+[metadata]
+lock-version = "1.1"
+python-versions = ">=3.7.1, <4.0"
+content-hash = "76a1437f9477fb535379f8791d1e66cb9949dd9f7f4a18e09fc0cf0db192c977"
+
+[metadata.files]
+certifi = [
+    {file = "certifi-2021.10.8-py2.py3-none-any.whl", hash = "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"},
+    {file = "certifi-2021.10.8.tar.gz", hash = "sha256:78884e7c1d4b00ce3cea67b44566851c4343c120abd683433ce934a68ea58872"},
+]
+charset-normalizer = [
+    {file = "charset-normalizer-2.0.12.tar.gz", hash = "sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597"},
+    {file = "charset_normalizer-2.0.12-py3-none-any.whl", hash = "sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df"},
+]
+fire = [
+    {file = "fire-0.4.0.tar.gz", hash = "sha256:c5e2b8763699d1142393a46d0e3e790c5eb2f0706082df8f647878842c216a62"},
+]
+idna = [
+    {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},
+    {file = "idna-3.3.tar.gz", hash = "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"},
+]
+numpy = [
+    {file = "numpy-1.21.5-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:301e408a052fdcda5cdcf03021ebafc3c6ea093021bf9d1aa47c54d48bdad166"},
+    {file = "numpy-1.21.5-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:a7e8f6216f180f3fd4efb73de5d1eaefb5f5a1ee5b645c67333033e39440e63a"},
+    {file = "numpy-1.21.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:fc7a7d7b0ed72589fd8b8486b9b42a564f10b8762be8bd4d9df94b807af4a089"},
+    {file = "numpy-1.21.5-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:58ca1d7c8aef6e996112d0ce873ac9dfa1eaf4a1196b4ff7ff73880a09923ba7"},
+    {file = "numpy-1.21.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dc4b2fb01f1b4ddbe2453468ea0719f4dbb1f5caa712c8b21bb3dd1480cd30d9"},
+    {file = "numpy-1.21.5-cp310-cp310-win_amd64.whl", hash = "sha256:cc1b30205d138d1005adb52087ff45708febbef0e420386f58664f984ef56954"},
+    {file = "numpy-1.21.5-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:08de8472d9f7571f9d51b27b75e827f5296295fa78817032e84464be8bb905bc"},
+    {file = "numpy-1.21.5-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:4fe6a006557b87b352c04596a6e3f12a57d6e5f401d804947bd3188e6b0e0e76"},
+    {file = "numpy-1.21.5-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:3d893b0871322eaa2f8c7072cdb552d8e2b27645b7875a70833c31e9274d4611"},
+    {file = "numpy-1.21.5-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:341dddcfe3b7b6427a28a27baa59af5ad51baa59bfec3264f1ab287aa3b30b13"},
+    {file = "numpy-1.21.5-cp37-cp37m-win32.whl", hash = "sha256:ca9c23848292c6fe0a19d212790e62f398fd9609aaa838859be8459bfbe558aa"},
+    {file = "numpy-1.21.5-cp37-cp37m-win_amd64.whl", hash = "sha256:025b497014bc33fc23897859350f284323f32a2fff7654697f5a5fc2a19e9939"},
+    {file = "numpy-1.21.5-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:3a5098df115340fb17fc93867317a947e1dcd978c3888c5ddb118366095851f8"},
+    {file = "numpy-1.21.5-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:311283acf880cfcc20369201bd75da907909afc4666966c7895cbed6f9d2c640"},
+    {file = "numpy-1.21.5-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:b545ebadaa2b878c8630e5bcdb97fc4096e779f335fc0f943547c1c91540c815"},
+    {file = "numpy-1.21.5-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:c5562bcc1a9b61960fc8950ade44d00e3de28f891af0acc96307c73613d18f6e"},
+    {file = "numpy-1.21.5-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:eed2afaa97ec33b4411995be12f8bdb95c87984eaa28d76cf628970c8a2d689a"},
+    {file = "numpy-1.21.5-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:61bada43d494515d5b122f4532af226fdb5ee08fe5b5918b111279843dc6836a"},
+    {file = "numpy-1.21.5-cp38-cp38-win32.whl", hash = "sha256:7b9d6b14fc9a4864b08d1ba57d732b248f0e482c7b2ff55c313137e3ed4d8449"},
+    {file = "numpy-1.21.5-cp38-cp38-win_amd64.whl", hash = "sha256:dbce7adeb66b895c6aaa1fad796aaefc299ced597f6fbd9ceddb0dd735245354"},
+    {file = "numpy-1.21.5-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:507c05c7a37b3683eb08a3ff993bd1ee1e6c752f77c2f275260533b265ecdb6c"},
+    {file = "numpy-1.21.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:00c9fa73a6989895b8815d98300a20ac993c49ac36c8277e8ffeaa3631c0dbbb"},
+    {file = "numpy-1.21.5-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:69a5a8d71c308d7ef33ef72371c2388a90e3495dbb7993430e674006f94797d5"},
+    {file = "numpy-1.21.5-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:2d8adfca843bc46ac199a4645233f13abf2011a0b2f4affc5c37cd552626f27b"},
+    {file = "numpy-1.21.5-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:c293d3c0321996cd8ffe84215ffe5d269fd9d1d12c6f4ffe2b597a7c30d3e593"},
+    {file = "numpy-1.21.5-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3c978544be9e04ed12016dd295a74283773149b48f507d69b36f91aa90a643e5"},
+    {file = "numpy-1.21.5-cp39-cp39-win32.whl", hash = "sha256:2a9add27d7fc0fdb572abc3b2486eb3b1395da71e0254c5552b2aad2a18b5441"},
+    {file = "numpy-1.21.5-cp39-cp39-win_amd64.whl", hash = "sha256:1964db2d4a00348b7a60ee9d013c8cb0c566644a589eaa80995126eac3b99ced"},
+    {file = "numpy-1.21.5-pp37-pypy37_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:a7c4b701ca418cd39e28ec3b496e6388fe06de83f5f0cb74794fa31cfa384c02"},
+    {file = "numpy-1.21.5.zip", hash = "sha256:6a5928bc6241264dce5ed509e66f33676fc97f464e7a919edc672fb5532221ee"},
+    {file = "numpy-1.22.2-cp310-cp310-macosx_10_14_x86_64.whl", hash = "sha256:515a8b6edbb904594685da6e176ac9fbea8f73a5ebae947281de6613e27f1956"},
+    {file = "numpy-1.22.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:76a4f9bce0278becc2da7da3b8ef854bed41a991f4226911a24a9711baad672c"},
+    {file = "numpy-1.22.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:168259b1b184aa83a514f307352c25c56af111c269ffc109d9704e81f72e764b"},
+    {file = "numpy-1.22.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3556c5550de40027d3121ebbb170f61bbe19eb639c7ad0c7b482cd9b560cd23b"},
+    {file = "numpy-1.22.2-cp310-cp310-win_amd64.whl", hash = "sha256:aafa46b5a39a27aca566198d3312fb3bde95ce9677085efd02c86f7ef6be4ec7"},
+    {file = "numpy-1.22.2-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:55535c7c2f61e2b2fc817c5cbe1af7cb907c7f011e46ae0a52caa4be1f19afe2"},
+    {file = "numpy-1.22.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:60cb8e5933193a3cc2912ee29ca331e9c15b2da034f76159b7abc520b3d1233a"},
+    {file = "numpy-1.22.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0b536b6840e84c1c6a410f3a5aa727821e6108f3454d81a5cd5900999ef04f89"},
+    {file = "numpy-1.22.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2638389562bda1635b564490d76713695ff497242a83d9b684d27bb4a6cc9d7a"},
+    {file = "numpy-1.22.2-cp38-cp38-win32.whl", hash = "sha256:6767ad399e9327bfdbaa40871be4254d1995f4a3ca3806127f10cec778bd9896"},
+    {file = "numpy-1.22.2-cp38-cp38-win_amd64.whl", hash = "sha256:03ae5850619abb34a879d5f2d4bb4dcd025d6d8fb72f5e461dae84edccfe129f"},
+    {file = "numpy-1.22.2-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:d76a26c5118c4d96e264acc9e3242d72e1a2b92e739807b3b69d8d47684b6677"},
+    {file = "numpy-1.22.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:15efb7b93806d438e3bc590ca8ef2f953b0ce4f86f337ef4559d31ec6cf9d7dd"},
+    {file = "numpy-1.22.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:badca914580eb46385e7f7e4e426fea6de0a37b9e06bec252e481ae7ec287082"},
+    {file = "numpy-1.22.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:94dd11d9f13ea1be17bac39c1942f527cbf7065f94953cf62dfe805653da2f8f"},
+    {file = "numpy-1.22.2-cp39-cp39-win32.whl", hash = "sha256:8cf33634b60c9cef346663a222d9841d3bbbc0a2f00221d6bcfd0d993d5543f6"},
+    {file = "numpy-1.22.2-cp39-cp39-win_amd64.whl", hash = "sha256:59153979d60f5bfe9e4c00e401e24dfe0469ef8da6d68247439d3278f30a180f"},
+    {file = "numpy-1.22.2-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4a176959b6e7e00b5a0d6f549a479f869829bfd8150282c590deee6d099bbb6e"},
+    {file = "numpy-1.22.2.zip", hash = "sha256:076aee5a3763d41da6bef9565fdf3cb987606f567cd8b104aded2b38b7b47abf"},
+]
+pandas = [
+    {file = "pandas-1.3.5-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:62d5b5ce965bae78f12c1c0df0d387899dd4211ec0bdc52822373f13a3a022b9"},
+    {file = "pandas-1.3.5-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:adfeb11be2d54f275142c8ba9bf67acee771b7186a5745249c7d5a06c670136b"},
+    {file = "pandas-1.3.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:60a8c055d58873ad81cae290d974d13dd479b82cbb975c3e1fa2cf1920715296"},
+    {file = "pandas-1.3.5-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fd541ab09e1f80a2a1760032d665f6e032d8e44055d602d65eeea6e6e85498cb"},
+    {file = "pandas-1.3.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2651d75b9a167cc8cc572cf787ab512d16e316ae00ba81874b560586fa1325e0"},
+    {file = "pandas-1.3.5-cp310-cp310-win_amd64.whl", hash = "sha256:aaf183a615ad790801fa3cf2fa450e5b6d23a54684fe386f7e3208f8b9bfbef6"},
+    {file = "pandas-1.3.5-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:344295811e67f8200de2390093aeb3c8309f5648951b684d8db7eee7d1c81fb7"},
+    {file = "pandas-1.3.5-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:552020bf83b7f9033b57cbae65589c01e7ef1544416122da0c79140c93288f56"},
+    {file = "pandas-1.3.5-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5cce0c6bbeb266b0e39e35176ee615ce3585233092f685b6a82362523e59e5b4"},
+    {file = "pandas-1.3.5-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7d28a3c65463fd0d0ba8bbb7696b23073efee0510783340a44b08f5e96ffce0c"},
+    {file = "pandas-1.3.5-cp37-cp37m-win32.whl", hash = "sha256:a62949c626dd0ef7de11de34b44c6475db76995c2064e2d99c6498c3dba7fe58"},
+    {file = "pandas-1.3.5-cp37-cp37m-win_amd64.whl", hash = "sha256:8025750767e138320b15ca16d70d5cdc1886e8f9cc56652d89735c016cd8aea6"},
+    {file = "pandas-1.3.5-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:fe95bae4e2d579812865db2212bb733144e34d0c6785c0685329e5b60fcb85dd"},
+    {file = "pandas-1.3.5-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5f261553a1e9c65b7a310302b9dbac31cf0049a51695c14ebe04e4bfd4a96f02"},
+    {file = "pandas-1.3.5-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8b6dbec5f3e6d5dc80dcfee250e0a2a652b3f28663492f7dab9a24416a48ac39"},
+    {file = "pandas-1.3.5-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d3bc49af96cd6285030a64779de5b3688633a07eb75c124b0747134a63f4c05f"},
+    {file = "pandas-1.3.5-cp38-cp38-win32.whl", hash = "sha256:b6b87b2fb39e6383ca28e2829cddef1d9fc9e27e55ad91ca9c435572cdba51bf"},
+    {file = "pandas-1.3.5-cp38-cp38-win_amd64.whl", hash = "sha256:a395692046fd8ce1edb4c6295c35184ae0c2bbe787ecbe384251da609e27edcb"},
+    {file = "pandas-1.3.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:bd971a3f08b745a75a86c00b97f3007c2ea175951286cdda6abe543e687e5f2f"},
+    {file = "pandas-1.3.5-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:37f06b59e5bc05711a518aa10beaec10942188dccb48918bb5ae602ccbc9f1a0"},
+    {file = "pandas-1.3.5-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2c21778a688d3712d35710501f8001cdbf96eb70a7c587a3d5613573299fdca6"},
+    {file = "pandas-1.3.5-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3345343206546545bc26a05b4602b6a24385b5ec7c75cb6059599e3d56831da2"},
+    {file = "pandas-1.3.5-cp39-cp39-win32.whl", hash = "sha256:c69406a2808ba6cf580c2255bcf260b3f214d2664a3a4197d0e640f573b46fd3"},
+    {file = "pandas-1.3.5-cp39-cp39-win_amd64.whl", hash = "sha256:32e1a26d5ade11b547721a72f9bfc4bd113396947606e00d5b4a5b79b3dcb006"},
+    {file = "pandas-1.3.5.tar.gz", hash = "sha256:1e4285f5de1012de20ca46b188ccf33521bff61ba5c5ebd78b4fb28e5416a9f1"},
+]
+python-dateutil = [
+    {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
+    {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
+]
+pytz = [
+    {file = "pytz-2021.3-py2.py3-none-any.whl", hash = "sha256:3672058bc3453457b622aab7a1c3bfd5ab0bdae451512f6cf25f64ed37f5b87c"},
+    {file = "pytz-2021.3.tar.gz", hash = "sha256:acad2d8b20a1af07d4e4c9d2e9285c5ed9104354062f275f3fcd88dcef4f1326"},
+]
+requests = [
+    {file = "requests-2.27.1-py2.py3-none-any.whl", hash = "sha256:f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d"},
+    {file = "requests-2.27.1.tar.gz", hash = "sha256:68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61"},
+]
+six = [
+    {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
+    {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
+]
+termcolor = [
+    {file = "termcolor-1.1.0.tar.gz", hash = "sha256:1d6d69ce66211143803fbc56652b41d73b4a400a2891d7bf7a1cdf4c02de613b"},
+]
+urllib3 = [
+    {file = "urllib3-1.26.8-py2.py3-none-any.whl", hash = "sha256:000ca7f471a233c2251c6c7023ee85305721bfdf18621ebff4fd17a8653427ed"},
+    {file = "urllib3-1.26.8.tar.gz", hash = "sha256:0e7c33d9a63e7ddfcb86780aac87befc2fbddf46c58dbb487e0855f7ceec283c"},
+]

--- a/poetry.lock
+++ b/poetry.lock
@@ -291,7 +291,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7.1, <4.0"
-content-hash = "74a9f06ad7bffdf95174edfcc5ed79545d3ee32410cbf408c4d19493950f2f0b"
+content-hash = "459e091f41809e5b092d11ca6c320974bf6ae5a6241ba214772fb1924be4678d"
 
 [metadata.files]
 certifi = [

--- a/poetry.lock
+++ b/poetry.lock
@@ -7,6 +7,14 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "cfgv"
+version = "3.3.1"
+description = "Validate configuration and produce human readable error messages."
+category = "dev"
+optional = false
+python-versions = ">=3.6.1"
+
+[[package]]
 name = "charset-normalizer"
 version = "2.0.12"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
@@ -16,6 +24,26 @@ python-versions = ">=3.5.0"
 
 [package.extras]
 unicode_backport = ["unicodedata2"]
+
+[[package]]
+name = "distlib"
+version = "0.3.4"
+description = "Distribution utilities"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "filelock"
+version = "3.6.0"
+description = "A platform independent file lock."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+docs = ["furo (>=2021.8.17b43)", "sphinx (>=4.1)", "sphinx-autodoc-typehints (>=1.12)"]
+testing = ["covdefaults (>=1.2.0)", "coverage (>=4)", "pytest (>=4)", "pytest-cov", "pytest-timeout (>=1.4.2)"]
 
 [[package]]
 name = "fire"
@@ -30,12 +58,48 @@ six = "*"
 termcolor = "*"
 
 [[package]]
+name = "identify"
+version = "2.4.12"
+description = "File identification library for Python"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+license = ["ukkonen"]
+
+[[package]]
 name = "idna"
 version = "3.3"
 description = "Internationalized Domain Names in Applications (IDNA)"
 category = "main"
 optional = false
 python-versions = ">=3.5"
+
+[[package]]
+name = "importlib-metadata"
+version = "4.11.3"
+description = "Read metadata from Python packages"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+typing-extensions = {version = ">=3.6.4", markers = "python_version < \"3.8\""}
+zipp = ">=0.5"
+
+[package.extras]
+docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)"]
+perf = ["ipython"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "packaging", "pyfakefs", "flufl.flake8", "pytest-perf (>=0.9.2)", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)", "importlib-resources (>=1.3)"]
+
+[[package]]
+name = "nodeenv"
+version = "1.6.0"
+description = "Node.js virtual environment builder"
+category = "dev"
+optional = false
+python-versions = "*"
 
 [[package]]
 name = "numpy"
@@ -47,7 +111,7 @@ python-versions = ">=3.7,<3.11"
 
 [[package]]
 name = "numpy"
-version = "1.22.2"
+version = "1.22.3"
 description = "NumPy is the fundamental package for array computing with Python."
 category = "main"
 optional = false
@@ -75,6 +139,35 @@ pytz = ">=2017.3"
 test = ["hypothesis (>=3.58)", "pytest (>=6.0)", "pytest-xdist"]
 
 [[package]]
+name = "platformdirs"
+version = "2.5.1"
+description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+docs = ["Sphinx (>=4)", "furo (>=2021.7.5b38)", "proselint (>=0.10.2)", "sphinx-autodoc-typehints (>=1.12)"]
+test = ["appdirs (==1.4.4)", "pytest (>=6)", "pytest-cov (>=2.7)", "pytest-mock (>=3.6)"]
+
+[[package]]
+name = "pre-commit"
+version = "2.17.0"
+description = "A framework for managing and maintaining multi-language pre-commit hooks."
+category = "dev"
+optional = false
+python-versions = ">=3.6.1"
+
+[package.dependencies]
+cfgv = ">=2.0.0"
+identify = ">=1.0.0"
+importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
+nodeenv = ">=0.11.1"
+pyyaml = ">=5.1"
+toml = "*"
+virtualenv = ">=20.0.8"
+
+[[package]]
 name = "python-dateutil"
 version = "2.8.2"
 description = "Extensions to the standard Python datetime module"
@@ -87,11 +180,19 @@ six = ">=1.5"
 
 [[package]]
 name = "pytz"
-version = "2021.3"
+version = "2022.1"
 description = "World timezone definitions, modern and historical"
 category = "main"
 optional = false
 python-versions = "*"
+
+[[package]]
+name = "pyyaml"
+version = "6.0"
+description = "YAML parser and emitter for Python"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
 
 [[package]]
 name = "requests"
@@ -128,38 +229,109 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "toml"
+version = "0.10.2"
+description = "Python Library for Tom's Obvious, Minimal Language"
+category = "dev"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+
+[[package]]
+name = "typing-extensions"
+version = "4.1.1"
+description = "Backported and Experimental Type Hints for Python 3.6+"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
 name = "urllib3"
-version = "1.26.8"
+version = "1.26.9"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
 
 [package.extras]
-brotli = ["brotlipy (>=0.6.0)"]
+brotli = ["brotlicffi (>=0.8.0)", "brotli (>=1.0.9)", "brotlipy (>=0.6.0)"]
 secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
 socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
+
+[[package]]
+name = "virtualenv"
+version = "20.13.4"
+description = "Virtual Python Environment builder"
+category = "dev"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+
+[package.dependencies]
+distlib = ">=0.3.1,<1"
+filelock = ">=3.2,<4"
+importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
+platformdirs = ">=2,<3"
+six = ">=1.9.0,<2"
+
+[package.extras]
+docs = ["proselint (>=0.10.2)", "sphinx (>=3)", "sphinx-argparse (>=0.2.5)", "sphinx-rtd-theme (>=0.4.3)", "towncrier (>=21.3)"]
+testing = ["coverage (>=4)", "coverage-enable-subprocess (>=1)", "flaky (>=3)", "pytest (>=4)", "pytest-env (>=0.6.2)", "pytest-freezegun (>=0.4.1)", "pytest-mock (>=2)", "pytest-randomly (>=1)", "pytest-timeout (>=1)", "packaging (>=20.0)"]
+
+[[package]]
+name = "zipp"
+version = "3.7.0"
+description = "Backport of pathlib-compatible object wrapper for zip files"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7.1, <4.0"
-content-hash = "76a1437f9477fb535379f8791d1e66cb9949dd9f7f4a18e09fc0cf0db192c977"
+content-hash = "74a9f06ad7bffdf95174edfcc5ed79545d3ee32410cbf408c4d19493950f2f0b"
 
 [metadata.files]
 certifi = [
     {file = "certifi-2021.10.8-py2.py3-none-any.whl", hash = "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"},
     {file = "certifi-2021.10.8.tar.gz", hash = "sha256:78884e7c1d4b00ce3cea67b44566851c4343c120abd683433ce934a68ea58872"},
 ]
+cfgv = [
+    {file = "cfgv-3.3.1-py2.py3-none-any.whl", hash = "sha256:c6a0883f3917a037485059700b9e75da2464e6c27051014ad85ba6aaa5884426"},
+    {file = "cfgv-3.3.1.tar.gz", hash = "sha256:f5a830efb9ce7a445376bb66ec94c638a9787422f96264c98edc6bdeed8ab736"},
+]
 charset-normalizer = [
     {file = "charset-normalizer-2.0.12.tar.gz", hash = "sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597"},
     {file = "charset_normalizer-2.0.12-py3-none-any.whl", hash = "sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df"},
 ]
+distlib = [
+    {file = "distlib-0.3.4-py2.py3-none-any.whl", hash = "sha256:6564fe0a8f51e734df6333d08b8b94d4ea8ee6b99b5ed50613f731fd4089f34b"},
+    {file = "distlib-0.3.4.zip", hash = "sha256:e4b58818180336dc9c529bfb9a0b58728ffc09ad92027a3f30b7cd91e3458579"},
+]
+filelock = [
+    {file = "filelock-3.6.0-py3-none-any.whl", hash = "sha256:f8314284bfffbdcfa0ff3d7992b023d4c628ced6feb957351d4c48d059f56bc0"},
+    {file = "filelock-3.6.0.tar.gz", hash = "sha256:9cd540a9352e432c7246a48fe4e8712b10acb1df2ad1f30e8c070b82ae1fed85"},
+]
 fire = [
     {file = "fire-0.4.0.tar.gz", hash = "sha256:c5e2b8763699d1142393a46d0e3e790c5eb2f0706082df8f647878842c216a62"},
+]
+identify = [
+    {file = "identify-2.4.12-py2.py3-none-any.whl", hash = "sha256:5f06b14366bd1facb88b00540a1de05b69b310cbc2654db3c7e07fa3a4339323"},
+    {file = "identify-2.4.12.tar.gz", hash = "sha256:3f3244a559290e7d3deb9e9adc7b33594c1bc85a9dd82e0f1be519bf12a1ec17"},
 ]
 idna = [
     {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},
     {file = "idna-3.3.tar.gz", hash = "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"},
+]
+importlib-metadata = [
+    {file = "importlib_metadata-4.11.3-py3-none-any.whl", hash = "sha256:1208431ca90a8cca1a6b8af391bb53c1a2db74e5d1cef6ddced95d4b2062edc6"},
+    {file = "importlib_metadata-4.11.3.tar.gz", hash = "sha256:ea4c597ebf37142f827b8f39299579e31685c31d3a438b59f469406afd0f2539"},
+]
+nodeenv = [
+    {file = "nodeenv-1.6.0-py2.py3-none-any.whl", hash = "sha256:621e6b7076565ddcacd2db0294c0381e01fd28945ab36bcf00f41c5daf63bef7"},
+    {file = "nodeenv-1.6.0.tar.gz", hash = "sha256:3ef13ff90291ba2a4a7a4ff9a979b63ffdd00a464dbe04acf0ea6471517a4c2b"},
 ]
 numpy = [
     {file = "numpy-1.21.5-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:301e408a052fdcda5cdcf03021ebafc3c6ea093021bf9d1aa47c54d48bdad166"},
@@ -192,25 +364,26 @@ numpy = [
     {file = "numpy-1.21.5-cp39-cp39-win_amd64.whl", hash = "sha256:1964db2d4a00348b7a60ee9d013c8cb0c566644a589eaa80995126eac3b99ced"},
     {file = "numpy-1.21.5-pp37-pypy37_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:a7c4b701ca418cd39e28ec3b496e6388fe06de83f5f0cb74794fa31cfa384c02"},
     {file = "numpy-1.21.5.zip", hash = "sha256:6a5928bc6241264dce5ed509e66f33676fc97f464e7a919edc672fb5532221ee"},
-    {file = "numpy-1.22.2-cp310-cp310-macosx_10_14_x86_64.whl", hash = "sha256:515a8b6edbb904594685da6e176ac9fbea8f73a5ebae947281de6613e27f1956"},
-    {file = "numpy-1.22.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:76a4f9bce0278becc2da7da3b8ef854bed41a991f4226911a24a9711baad672c"},
-    {file = "numpy-1.22.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:168259b1b184aa83a514f307352c25c56af111c269ffc109d9704e81f72e764b"},
-    {file = "numpy-1.22.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3556c5550de40027d3121ebbb170f61bbe19eb639c7ad0c7b482cd9b560cd23b"},
-    {file = "numpy-1.22.2-cp310-cp310-win_amd64.whl", hash = "sha256:aafa46b5a39a27aca566198d3312fb3bde95ce9677085efd02c86f7ef6be4ec7"},
-    {file = "numpy-1.22.2-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:55535c7c2f61e2b2fc817c5cbe1af7cb907c7f011e46ae0a52caa4be1f19afe2"},
-    {file = "numpy-1.22.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:60cb8e5933193a3cc2912ee29ca331e9c15b2da034f76159b7abc520b3d1233a"},
-    {file = "numpy-1.22.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0b536b6840e84c1c6a410f3a5aa727821e6108f3454d81a5cd5900999ef04f89"},
-    {file = "numpy-1.22.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2638389562bda1635b564490d76713695ff497242a83d9b684d27bb4a6cc9d7a"},
-    {file = "numpy-1.22.2-cp38-cp38-win32.whl", hash = "sha256:6767ad399e9327bfdbaa40871be4254d1995f4a3ca3806127f10cec778bd9896"},
-    {file = "numpy-1.22.2-cp38-cp38-win_amd64.whl", hash = "sha256:03ae5850619abb34a879d5f2d4bb4dcd025d6d8fb72f5e461dae84edccfe129f"},
-    {file = "numpy-1.22.2-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:d76a26c5118c4d96e264acc9e3242d72e1a2b92e739807b3b69d8d47684b6677"},
-    {file = "numpy-1.22.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:15efb7b93806d438e3bc590ca8ef2f953b0ce4f86f337ef4559d31ec6cf9d7dd"},
-    {file = "numpy-1.22.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:badca914580eb46385e7f7e4e426fea6de0a37b9e06bec252e481ae7ec287082"},
-    {file = "numpy-1.22.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:94dd11d9f13ea1be17bac39c1942f527cbf7065f94953cf62dfe805653da2f8f"},
-    {file = "numpy-1.22.2-cp39-cp39-win32.whl", hash = "sha256:8cf33634b60c9cef346663a222d9841d3bbbc0a2f00221d6bcfd0d993d5543f6"},
-    {file = "numpy-1.22.2-cp39-cp39-win_amd64.whl", hash = "sha256:59153979d60f5bfe9e4c00e401e24dfe0469ef8da6d68247439d3278f30a180f"},
-    {file = "numpy-1.22.2-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4a176959b6e7e00b5a0d6f549a479f869829bfd8150282c590deee6d099bbb6e"},
-    {file = "numpy-1.22.2.zip", hash = "sha256:076aee5a3763d41da6bef9565fdf3cb987606f567cd8b104aded2b38b7b47abf"},
+    {file = "numpy-1.22.3-cp310-cp310-macosx_10_14_x86_64.whl", hash = "sha256:92bfa69cfbdf7dfc3040978ad09a48091143cffb778ec3b03fa170c494118d75"},
+    {file = "numpy-1.22.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8251ed96f38b47b4295b1ae51631de7ffa8260b5b087808ef09a39a9d66c97ab"},
+    {file = "numpy-1.22.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:48a3aecd3b997bf452a2dedb11f4e79bc5bfd21a1d4cc760e703c31d57c84b3e"},
+    {file = "numpy-1.22.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a3bae1a2ed00e90b3ba5f7bd0a7c7999b55d609e0c54ceb2b076a25e345fa9f4"},
+    {file = "numpy-1.22.3-cp310-cp310-win32.whl", hash = "sha256:f950f8845b480cffe522913d35567e29dd381b0dc7e4ce6a4a9f9156417d2430"},
+    {file = "numpy-1.22.3-cp310-cp310-win_amd64.whl", hash = "sha256:08d9b008d0156c70dc392bb3ab3abb6e7a711383c3247b410b39962263576cd4"},
+    {file = "numpy-1.22.3-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:201b4d0552831f7250a08d3b38de0d989d6f6e4658b709a02a73c524ccc6ffce"},
+    {file = "numpy-1.22.3-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:f8c1f39caad2c896bc0018f699882b345b2a63708008be29b1f355ebf6f933fe"},
+    {file = "numpy-1.22.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:568dfd16224abddafb1cbcce2ff14f522abe037268514dd7e42c6776a1c3f8e5"},
+    {file = "numpy-1.22.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3ca688e1b9b95d80250bca34b11a05e389b1420d00e87a0d12dc45f131f704a1"},
+    {file = "numpy-1.22.3-cp38-cp38-win32.whl", hash = "sha256:e7927a589df200c5e23c57970bafbd0cd322459aa7b1ff73b7c2e84d6e3eae62"},
+    {file = "numpy-1.22.3-cp38-cp38-win_amd64.whl", hash = "sha256:07a8c89a04997625236c5ecb7afe35a02af3896c8aa01890a849913a2309c676"},
+    {file = "numpy-1.22.3-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:2c10a93606e0b4b95c9b04b77dc349b398fdfbda382d2a39ba5a822f669a0123"},
+    {file = "numpy-1.22.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:fade0d4f4d292b6f39951b6836d7a3c7ef5b2347f3c420cd9820a1d90d794802"},
+    {file = "numpy-1.22.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5bfb1bb598e8229c2d5d48db1860bcf4311337864ea3efdbe1171fb0c5da515d"},
+    {file = "numpy-1.22.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:97098b95aa4e418529099c26558eeb8486e66bd1e53a6b606d684d0c3616b168"},
+    {file = "numpy-1.22.3-cp39-cp39-win32.whl", hash = "sha256:fdf3c08bce27132395d3c3ba1503cac12e17282358cb4bddc25cc46b0aca07aa"},
+    {file = "numpy-1.22.3-cp39-cp39-win_amd64.whl", hash = "sha256:639b54cdf6aa4f82fe37ebf70401bbb74b8508fddcf4797f9fe59615b8c5813a"},
+    {file = "numpy-1.22.3-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c34ea7e9d13a70bf2ab64a2532fe149a9aced424cd05a2c4ba662fd989e3e45f"},
+    {file = "numpy-1.22.3.zip", hash = "sha256:dbc7601a3b7472d559dc7b933b18b4b66f9aa7452c120e87dfb33d02008c8a18"},
 ]
 pandas = [
     {file = "pandas-1.3.5-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:62d5b5ce965bae78f12c1c0df0d387899dd4211ec0bdc52822373f13a3a022b9"},
@@ -239,13 +412,56 @@ pandas = [
     {file = "pandas-1.3.5-cp39-cp39-win_amd64.whl", hash = "sha256:32e1a26d5ade11b547721a72f9bfc4bd113396947606e00d5b4a5b79b3dcb006"},
     {file = "pandas-1.3.5.tar.gz", hash = "sha256:1e4285f5de1012de20ca46b188ccf33521bff61ba5c5ebd78b4fb28e5416a9f1"},
 ]
+platformdirs = [
+    {file = "platformdirs-2.5.1-py3-none-any.whl", hash = "sha256:bcae7cab893c2d310a711b70b24efb93334febe65f8de776ee320b517471e227"},
+    {file = "platformdirs-2.5.1.tar.gz", hash = "sha256:7535e70dfa32e84d4b34996ea99c5e432fa29a708d0f4e394bbcb2a8faa4f16d"},
+]
+pre-commit = [
+    {file = "pre_commit-2.17.0-py2.py3-none-any.whl", hash = "sha256:725fa7459782d7bec5ead072810e47351de01709be838c2ce1726b9591dad616"},
+    {file = "pre_commit-2.17.0.tar.gz", hash = "sha256:c1a8040ff15ad3d648c70cc3e55b93e4d2d5b687320955505587fd79bbaed06a"},
+]
 python-dateutil = [
     {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
     {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
 ]
 pytz = [
-    {file = "pytz-2021.3-py2.py3-none-any.whl", hash = "sha256:3672058bc3453457b622aab7a1c3bfd5ab0bdae451512f6cf25f64ed37f5b87c"},
-    {file = "pytz-2021.3.tar.gz", hash = "sha256:acad2d8b20a1af07d4e4c9d2e9285c5ed9104354062f275f3fcd88dcef4f1326"},
+    {file = "pytz-2022.1-py2.py3-none-any.whl", hash = "sha256:e68985985296d9a66a881eb3193b0906246245294a881e7c8afe623866ac6a5c"},
+    {file = "pytz-2022.1.tar.gz", hash = "sha256:1e760e2fe6a8163bc0b3d9a19c4f84342afa0a2affebfaa84b01b978a02ecaa7"},
+]
+pyyaml = [
+    {file = "PyYAML-6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d4db7c7aef085872ef65a8fd7d6d09a14ae91f691dec3e87ee5ee0539d516f53"},
+    {file = "PyYAML-6.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9df7ed3b3d2e0ecfe09e14741b857df43adb5a3ddadc919a2d94fbdf78fea53c"},
+    {file = "PyYAML-6.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77f396e6ef4c73fdc33a9157446466f1cff553d979bd00ecb64385760c6babdc"},
+    {file = "PyYAML-6.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a80a78046a72361de73f8f395f1f1e49f956c6be882eed58505a15f3e430962b"},
+    {file = "PyYAML-6.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f84fbc98b019fef2ee9a1cb3ce93e3187a6df0b2538a651bfb890254ba9f90b5"},
+    {file = "PyYAML-6.0-cp310-cp310-win32.whl", hash = "sha256:2cd5df3de48857ed0544b34e2d40e9fac445930039f3cfe4bcc592a1f836d513"},
+    {file = "PyYAML-6.0-cp310-cp310-win_amd64.whl", hash = "sha256:daf496c58a8c52083df09b80c860005194014c3698698d1a57cbcfa182142a3a"},
+    {file = "PyYAML-6.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:897b80890765f037df3403d22bab41627ca8811ae55e9a722fd0392850ec4d86"},
+    {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:50602afada6d6cbfad699b0c7bb50d5ccffa7e46a3d738092afddc1f9758427f"},
+    {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:48c346915c114f5fdb3ead70312bd042a953a8ce5c7106d5bfb1a5254e47da92"},
+    {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:98c4d36e99714e55cfbaaee6dd5badbc9a1ec339ebfc3b1f52e293aee6bb71a4"},
+    {file = "PyYAML-6.0-cp36-cp36m-win32.whl", hash = "sha256:0283c35a6a9fbf047493e3a0ce8d79ef5030852c51e9d911a27badfde0605293"},
+    {file = "PyYAML-6.0-cp36-cp36m-win_amd64.whl", hash = "sha256:07751360502caac1c067a8132d150cf3d61339af5691fe9e87803040dbc5db57"},
+    {file = "PyYAML-6.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:819b3830a1543db06c4d4b865e70ded25be52a2e0631ccd2f6a47a2822f2fd7c"},
+    {file = "PyYAML-6.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:473f9edb243cb1935ab5a084eb238d842fb8f404ed2193a915d1784b5a6b5fc0"},
+    {file = "PyYAML-6.0-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0ce82d761c532fe4ec3f87fc45688bdd3a4c1dc5e0b4a19814b9009a29baefd4"},
+    {file = "PyYAML-6.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:231710d57adfd809ef5d34183b8ed1eeae3f76459c18fb4a0b373ad56bedcdd9"},
+    {file = "PyYAML-6.0-cp37-cp37m-win32.whl", hash = "sha256:c5687b8d43cf58545ade1fe3e055f70eac7a5a1a0bf42824308d868289a95737"},
+    {file = "PyYAML-6.0-cp37-cp37m-win_amd64.whl", hash = "sha256:d15a181d1ecd0d4270dc32edb46f7cb7733c7c508857278d3d378d14d606db2d"},
+    {file = "PyYAML-6.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:0b4624f379dab24d3725ffde76559cff63d9ec94e1736b556dacdfebe5ab6d4b"},
+    {file = "PyYAML-6.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:213c60cd50106436cc818accf5baa1aba61c0189ff610f64f4a3e8c6726218ba"},
+    {file = "PyYAML-6.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9fa600030013c4de8165339db93d182b9431076eb98eb40ee068700c9c813e34"},
+    {file = "PyYAML-6.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:277a0ef2981ca40581a47093e9e2d13b3f1fbbeffae064c1d21bfceba2030287"},
+    {file = "PyYAML-6.0-cp38-cp38-win32.whl", hash = "sha256:d4eccecf9adf6fbcc6861a38015c2a64f38b9d94838ac1810a9023a0609e1b78"},
+    {file = "PyYAML-6.0-cp38-cp38-win_amd64.whl", hash = "sha256:1e4747bc279b4f613a09eb64bba2ba602d8a6664c6ce6396a4d0cd413a50ce07"},
+    {file = "PyYAML-6.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:055d937d65826939cb044fc8c9b08889e8c743fdc6a32b33e2390f66013e449b"},
+    {file = "PyYAML-6.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e61ceaab6f49fb8bdfaa0f92c4b57bcfbea54c09277b1b4f7ac376bfb7a7c174"},
+    {file = "PyYAML-6.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d67d839ede4ed1b28a4e8909735fc992a923cdb84e618544973d7dfc71540803"},
+    {file = "PyYAML-6.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cba8c411ef271aa037d7357a2bc8f9ee8b58b9965831d9e51baf703280dc73d3"},
+    {file = "PyYAML-6.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:40527857252b61eacd1d9af500c3337ba8deb8fc298940291486c465c8b46ec0"},
+    {file = "PyYAML-6.0-cp39-cp39-win32.whl", hash = "sha256:b5b9eccad747aabaaffbc6064800670f0c297e52c12754eb1d976c57e4f74dcb"},
+    {file = "PyYAML-6.0-cp39-cp39-win_amd64.whl", hash = "sha256:b3d267842bf12586ba6c734f89d1f5b871df0273157918b0ccefa29deb05c21c"},
+    {file = "PyYAML-6.0.tar.gz", hash = "sha256:68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2"},
 ]
 requests = [
     {file = "requests-2.27.1-py2.py3-none-any.whl", hash = "sha256:f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d"},
@@ -258,7 +474,23 @@ six = [
 termcolor = [
     {file = "termcolor-1.1.0.tar.gz", hash = "sha256:1d6d69ce66211143803fbc56652b41d73b4a400a2891d7bf7a1cdf4c02de613b"},
 ]
+toml = [
+    {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
+    {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
+]
+typing-extensions = [
+    {file = "typing_extensions-4.1.1-py3-none-any.whl", hash = "sha256:21c85e0fe4b9a155d0799430b0ad741cdce7e359660ccbd8b530613e8df88ce2"},
+    {file = "typing_extensions-4.1.1.tar.gz", hash = "sha256:1a9462dcc3347a79b1f1c0271fbe79e844580bb598bafa1ed208b94da3cdcd42"},
+]
 urllib3 = [
-    {file = "urllib3-1.26.8-py2.py3-none-any.whl", hash = "sha256:000ca7f471a233c2251c6c7023ee85305721bfdf18621ebff4fd17a8653427ed"},
-    {file = "urllib3-1.26.8.tar.gz", hash = "sha256:0e7c33d9a63e7ddfcb86780aac87befc2fbddf46c58dbb487e0855f7ceec283c"},
+    {file = "urllib3-1.26.9-py2.py3-none-any.whl", hash = "sha256:44ece4d53fb1706f667c9bd1c648f5469a2ec925fcf3a776667042d645472c14"},
+    {file = "urllib3-1.26.9.tar.gz", hash = "sha256:aabaf16477806a5e1dd19aa41f8c2b7950dd3c746362d7e3223dbe6de6ac448e"},
+]
+virtualenv = [
+    {file = "virtualenv-20.13.4-py2.py3-none-any.whl", hash = "sha256:c3e01300fb8495bc00ed70741f5271fc95fed067eb7106297be73d30879af60c"},
+    {file = "virtualenv-20.13.4.tar.gz", hash = "sha256:ce8901d3bbf3b90393498187f2d56797a8a452fb2d0d7efc6fd837554d6f679c"},
+]
+zipp = [
+    {file = "zipp-3.7.0-py3-none-any.whl", hash = "sha256:b47250dd24f92b7dd6a0a8fc5244da14608f3ca90a5efcd37a3b1642fac9a375"},
+    {file = "zipp-3.7.0.tar.gz", hash = "sha256:9f50f446828eb9d45b267433fd3e9da8d801f614129124863f9c51ebceafb87d"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,17 +29,16 @@ pandas = "^1.3"
 fire = "^0.4"
 
 [tool.poetry.dev-dependencies]
-pre-commit
+pre-commit = "^2"
 
 [tool.black]
 line-length = 88
 include = '\.pyi?$'
-exclude = '''
-/(
-    \.git
-  | docs
-  | notebook
-)/
+extend-exclude = '''
+    .git
+    __pycache__
+    notebooks
+    docs
 '''
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,13 @@ pre-commit
 [tool.black]
 line-length = 88
 include = '\.pyi?$'
+exclude = '''
+/(
+    \.git
+  | docs
+  | notebook
+)/
+'''
 
 [build-system]
 requires = ["poetry_core>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,12 +34,6 @@ pre-commit = "^2"
 [tool.black]
 line-length = 88
 include = '\.pyi?$'
-extend-exclude = '''
-    .git
-    __pycache__
-    notebooks
-    docs
-'''
 
 [build-system]
 requires = ["poetry_core>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,9 @@ pandas = "^1.3"
 fire = "^0.4"
 
 [tool.poetry.dev-dependencies]
+black = "^22.1"
+flake8 "^2.17"
+pre-commit
 
 [build-system]
 requires = ["poetry_core>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,9 +29,11 @@ pandas = "^1.3"
 fire = "^0.4"
 
 [tool.poetry.dev-dependencies]
-black = "^22.1"
-flake8 "^2.17"
 pre-commit
+
+[tool.black]
+line-length = 88
+include = '\.pyi?$'
 
 [build-system]
 requires = ["poetry_core>=1.0.0"]

--- a/src/pyeuropeana/__init__.py
+++ b/src/pyeuropeana/__init__.py
@@ -6,4 +6,3 @@ from .apis.record import record as record
 
 from .apis import entity as entity
 from .apis import iiif as iiif
-

--- a/src/pyeuropeana/apis/entity.py
+++ b/src/pyeuropeana/apis/entity.py
@@ -1,101 +1,109 @@
 import requests
 from ..utils.auth import get_api_key
 
+
 def suggest(**kwargs):
-  """
-  Suggest method of the Entity API [1]. Returns entities based on a text query
+    """
+    Suggest method of the Entity API [1]. Returns entities based on a text query
 
-  >>> import pyeuropeana.apis as apis
-  >>> resp = apis.entity.suggest(
-  >>>    text = 'leonardo',
-  >>>    TYPE = 'agent',
-  >>>    language = 'de',
-  >>>     )
-  
-  Args:
-      text (:obj:`str`)
-        The search term(s)
-      TYPE (:obj:`str`, optional)
-         Used to restrict search for a specific entity type (agents, places, concepts and time spans), otherwise all.
-      language (:obj:`str`, optional)
-         The language (two or three letters ISO639 language code) in which the text is written. If omitted, defaults to English ("en").
-                              
-  Returns: :obj:`dict`
-    The suggest method returns a list of 10 suggest entities. For some entities (in particular people/agents) it returns some contextual
-    information is known such as the profession, date of birth and date of death. For other entities it just returns the label (prefLabel) 
-    in the given language, the entity type and the entity identifier. For a full list of data fields, please see the Entity context definition.
+    >>> import pyeuropeana.apis as apis
+    >>> resp = apis.entity.suggest(
+    >>>    text = 'leonardo',
+    >>>    TYPE = 'agent',
+    >>>    language = 'de',
+    >>>     )
 
-  References: 
-    1. https://pro.europeana.eu/page/entity
- 
-  """
-  wskey = get_api_key()
-  language = kwargs.get('language','en')
-  TYPE = kwargs.get('TYPE')
-  text = kwargs.get('text')
-  if not kwargs:
-    raise ValueError('No arguments passed')
-  if not text:
-    raise ValueError('Argument "text" is needed')
-  return requests.get(f'https://api.europeana.eu/entity/suggest',params = {'wskey':wskey,'text':text,'type':TYPE,'language':language}).json()
+    Args:
+        text (:obj:`str`)
+          The search term(s)
+        TYPE (:obj:`str`, optional)
+           Used to restrict search for a specific entity type (agents, places, concepts and time spans), otherwise all.
+        language (:obj:`str`, optional)
+           The language (two or three letters ISO639 language code) in which the text is written. If omitted, defaults to English ("en").
+
+    Returns: :obj:`dict`
+      The suggest method returns a list of 10 suggest entities. For some entities (in particular people/agents) it returns some contextual
+      information is known such as the profession, date of birth and date of death. For other entities it just returns the label (prefLabel)
+      in the given language, the entity type and the entity identifier. For a full list of data fields, please see the Entity context definition.
+
+    References:
+      1. https://pro.europeana.eu/page/entity
+
+    """
+    wskey = get_api_key()
+    language = kwargs.get("language", "en")
+    TYPE = kwargs.get("TYPE")
+    text = kwargs.get("text")
+    if not kwargs:
+        raise ValueError("No arguments passed")
+    if not text:
+        raise ValueError('Argument "text" is needed')
+    return requests.get(
+        "https://api.europeana.eu/entity/suggest",
+        params={"wskey": wskey, "text": text, "type": TYPE, "language": language},
+    ).json()
 
 
 def retrieve(**kwargs):
-  """
-  Retrieve method of the Entity API [1]. Returns information about a particular entity
+    """
+    Retrieve method of the Entity API [1]. Returns information about a particular entity
 
-  >>> import pyeuropeana.apis as apis
-  >>> resp = apis.entity.retrieve(
-  >>>    TYPE = 'agent',
-  >>>    IDENTIFIER = 3,
-  >>>     )
-  
-  Args:
-    TYPE (:obj:`str`)
-        The type of the entity, either: "agent", "concept", "place" or "timespan".
-    IDENTIFIER (:obj:`int`)
-        The local identifier for the entity.
+    >>> import pyeuropeana.apis as apis
+    >>> resp = apis.entity.retrieve(
+    >>>    TYPE = 'agent',
+    >>>    IDENTIFIER = 3,
+    >>>     )
 
-  Returns: :obj:`dict`
-    The retrieve method returns all known information about an entity in all languages in which the information is available.
-    This includes all localised labels (prefLabel), contextual information such as biography and all references of the same entity
-    in other external data sources (sameAs). For a full list of data fields, please see the Entity context definition.
+    Args:
+      TYPE (:obj:`str`)
+          The type of the entity, either: "agent", "concept", "place" or "timespan".
+      IDENTIFIER (:obj:`int`)
+          The local identifier for the entity.
 
-  References:
-    1. https://pro.europeana.eu/page/entity
- 
-  """
-  wskey = get_api_key()
-  TYPE = kwargs.get('TYPE')
-  IDENTIFIER = kwargs.get('IDENTIFIER')
-  if not kwargs:
-    raise ValueError('No arguments passed')
-  return requests.get(f'https://api.europeana.eu/entity/{TYPE}/base/{IDENTIFIER}.json',params = {'wskey':wskey}).json()
+    Returns: :obj:`dict`
+      The retrieve method returns all known information about an entity in all languages in which the information is available.
+      This includes all localised labels (prefLabel), contextual information such as biography and all references of the same entity
+      in other external data sources (sameAs). For a full list of data fields, please see the Entity context definition.
+
+    References:
+      1. https://pro.europeana.eu/page/entity
+
+    """
+    wskey = get_api_key()
+    TYPE = kwargs.get("TYPE")
+    IDENTIFIER = kwargs.get("IDENTIFIER")
+    if not kwargs:
+        raise ValueError("No arguments passed")
+    return requests.get(
+        f"https://api.europeana.eu/entity/{TYPE}/base/{IDENTIFIER}.json",
+        params={"wskey": wskey},
+    ).json()
+
 
 def resolve(uri):
-  """
-  Resolve method of the Entity API [1]. Searches for an entity given an input URI
+    """
+    Resolve method of the Entity API [1]. Searches for an entity given an input URI
 
-  >>> import pyeuropeana.apis as apis
-  >>> resp = apis.entity.resolve('http://dbpedia.org/resource/Leonardo_da_Vinci')
+    >>> import pyeuropeana.apis as apis
+    >>> resp = apis.entity.resolve('http://dbpedia.org/resource/Leonardo_da_Vinci')
 
-  Args:
-    uri (:obj:`str`)
-        The external identifier (as an URI) for the entity.
+    Args:
+      uri (:obj:`str`)
+          The external identifier (as an URI) for the entity.
 
-  Returns: :obj:`dict`
-    On success, the method returns a HTTP 301 with the Europeana URI within the Location Header field.
+    Returns: :obj:`dict`
+      On success, the method returns a HTTP 301 with the Europeana URI within the Location Header field.
 
-  References:
-    1. https://pro.europeana.eu/page/entity
- 
-  """
-  wskey = get_api_key()
-  if not isinstance(uri,str):
-    raise ValueError('input uri must be a string')
-  response = requests.get(f'https://api.europeana.eu/entity/resolve/',params = {'wskey':wskey,'uri':uri}).json()
-  if 'success' in  response.keys():
-    raise ValueError(response['error'])
-  return response
-   
+    References:
+      1. https://pro.europeana.eu/page/entity
 
+    """
+    wskey = get_api_key()
+    if not isinstance(uri, str):
+        raise ValueError("input uri must be a string")
+    response = requests.get(
+        "https://api.europeana.eu/entity/resolve/", params={"wskey": wskey, "uri": uri}
+    ).json()
+    if "success" in response.keys():
+        raise ValueError(response["error"])
+    return response

--- a/src/pyeuropeana/apis/iiif.py
+++ b/src/pyeuropeana/apis/iiif.py
@@ -7,76 +7,78 @@ from ..utils.edm_utils import cursor_search
 
 def search(**kwargs):
 
-  """
-  Search method of the IIIF API [1]. Allows to search newspapers by their text content
+    """
+    Search method of the IIIF API [1]. Allows to search newspapers by their text content
 
-  >>> import pyeuropeana.apis as apis
-  >>> resp = apis.iiif.search(
-  >>>    query = 'Paris',
-  >>>    profile = 'hits',
-  >>> )
-  
-  Args:
-    query (:obj:`str`)
-        The term to search
-    profile (:obj:`str`)
-        If profile is 'hits' the mentions in the transcribed text where the search keyword was found will be displayed
+    >>> import pyeuropeana.apis as apis
+    >>> resp = apis.iiif.search(
+    >>>    query = 'Paris',
+    >>>    profile = 'hits',
+    >>> )
 
-  Returns :obj:`dict`
-    Response
+    Args:
+      query (:obj:`str`)
+          The term to search
+      profile (:obj:`str`)
+          If profile is 'hits' the mentions in the transcribed text where the search keyword was found will be displayed
 
-  References:
-    1. https://pro.europeana.eu/page/iiif
-  """
+    Returns :obj:`dict`
+      Response
 
-  params = {
-      'wskey':get_api_key(),
-      'query':kwargs.get('query','*'), 
-      'qf':kwargs.get('qf'),
-      'reusability':kwargs.get('reusability'),
-      'media':kwargs.get('media'),
-      'thumbnail':kwargs.get('thumbnail'),
-      'landingpage':kwargs.get('landingpage'),
-      'colourpalette':kwargs.get('colourpalette'),
-      'theme':kwargs.get('theme'),
-      'sort':kwargs.get('sort','europeana_id'),
-      'profile':kwargs.get('profile'),
-      'rows':kwargs.get('rows',12),
-      'cursor':kwargs.get('cursor','*'),
-      'callback':kwargs.get('callback'),   
-      'facet':kwargs.get('facet'),
-  }
+    References:
+      1. https://pro.europeana.eu/page/iiif
+    """
 
-  endpoint = 'https://newspapers.eanadev.org/api/v2/search.json'
+    params = {
+        "wskey": get_api_key(),
+        "query": kwargs.get("query", "*"),
+        "qf": kwargs.get("qf"),
+        "reusability": kwargs.get("reusability"),
+        "media": kwargs.get("media"),
+        "thumbnail": kwargs.get("thumbnail"),
+        "landingpage": kwargs.get("landingpage"),
+        "colourpalette": kwargs.get("colourpalette"),
+        "theme": kwargs.get("theme"),
+        "sort": kwargs.get("sort", "europeana_id"),
+        "profile": kwargs.get("profile"),
+        "rows": kwargs.get("rows", 12),
+        "cursor": kwargs.get("cursor", "*"),
+        "callback": kwargs.get("callback"),
+        "facet": kwargs.get("facet"),
+    }
 
-  if not kwargs:
-    raise ValueError('No arguments passed')
+    endpoint = "https://newspapers.eanadev.org/api/v2/search.json"
 
-  # Necessary for handling facets of the type 'PROVIDER&f.PROVIDER.facet.limit=30&f.PROVIDER.facet.offset=10'
-  _params = params.copy()
+    if not kwargs:
+        raise ValueError("No arguments passed")
 
-  if _params['profile'] and 'hits' in _params['profile']:
-    hits_list = _params['profile'].split('&')
-    if len(hits_list)>1:
-      _params.update({'profile':hits_list[0]})
-      _params.update({item.split('=')[0]:item.split('=')[1] for item in hits_list[1:]})
+    # Necessary for handling facets of the type 'PROVIDER&f.PROVIDER.facet.limit=30&f.PROVIDER.facet.offset=10'
+    _params = params.copy()
 
-  response = requests.get(endpoint, params = _params)
-  url = response.url
+    if _params["profile"] and "hits" in _params["profile"]:
+        hits_list = _params["profile"].split("&")
+        if len(hits_list) > 1:
+            _params.update({"profile": hits_list[0]})
+            _params.update(
+                {item.split("=")[0]: item.split("=")[1] for item in hits_list[1:]}
+            )
 
-  response =  cursor_search(endpoint,_params)
-  response.update({'url':url, 'parms':params})
-  return response
+    response = requests.get(endpoint, params=_params)
+    url = response.url
+
+    response = cursor_search(endpoint, _params)
+    response.update({"url": url, "parms": params})
+    return response
 
 
 def manifest(RECORD_ID):
-  """
-  
+    """
+
   Manifest method of the IIIF API [1]. Returns a minimal set of metadata for an object
 
   >>> import pyeuropeana.apis as apis
   >>> resp = apis.iiif.manifest('/9200356/BibliographicResource_3000118390149')
-  
+
   Args:
     record_id (:obj:`str`)
         The identifier of the record which is composed of the dataset identifier \\
@@ -88,14 +90,18 @@ def manifest(RECORD_ID):
   References:
     1. https://pro.europeana.eu/page/iiif
   """
-  wskey = get_api_key()
-  europeana_id = re.findall('/\w*/\w*',RECORD_ID)
-  if not europeana_id:
-    raise ValueError('Not valid RECORD_ID')
-  return requests.get(f'https://iiif.europeana.eu/presentation{RECORD_ID}/manifest',params = {'wskey':wskey}).json()
+    wskey = get_api_key()
+    europeana_id = re.findall("/\w*/\w*", RECORD_ID)
+    if not europeana_id:
+        raise ValueError("Not valid RECORD_ID")
+    return requests.get(
+        f"https://iiif.europeana.eu/presentation{RECORD_ID}/manifest",
+        params={"wskey": wskey},
+    ).json()
+
 
 def annopage(**kwargs):
-  """
+    """
   Annopage method of the IIIF API [1]. Returns text and annotations for a given page of an object
 
   >>> import pyeuropeana.apis as apis
@@ -103,13 +109,13 @@ def annopage(**kwargs):
   >>>    RECORD_ID = '/9200356/BibliographicResource_3000118390149',
   >>>    PAGE_ID = 1,
   >>> )
-  
+
   Args:
     RECORD_ID (:obj:`str`)
         The identifier of the record which is composed of the dataset identifier \\
         plus a local identifier within the dataset in the form of "/DATASET_ID/LOCAL_ID", for more detail see Europeana ID [2]
     PAGE_ID (:obj:`int`)
-        The number of the page in logical sequence starting with 1 for the first page. 
+        The number of the page in logical sequence starting with 1 for the first page.
         There can be pages that do not contain any text which will mean that the request will return a HTTP 404.
 
   Returns :obj:`dict`
@@ -118,20 +124,24 @@ def annopage(**kwargs):
   References:
     1. https://pro.europeana.eu/page/iiif
   """
-  wskey = get_api_key()
-  RECORD_ID = kwargs.get('RECORD_ID')
-  PAGE_ID = kwargs.get('PAGE_ID')
-  if not kwargs:
-    raise ValueError('No arguments passed')
-  europeana_id = re.findall('/\w*/\w*',RECORD_ID)
-  if not europeana_id:
-    raise ValueError('Not valid RECORD_ID')
-  if not isinstance(PAGE_ID,int):
-      raise ValueError('PAGE_ID must be an int')
-  return requests.get(f'https://iiif.europeana.eu/presentation{RECORD_ID}/annopage/{PAGE_ID}',params = {'wskey':wskey}).json()
+    wskey = get_api_key()
+    RECORD_ID = kwargs.get("RECORD_ID")
+    PAGE_ID = kwargs.get("PAGE_ID")
+    if not kwargs:
+        raise ValueError("No arguments passed")
+    europeana_id = re.findall("/\w*/\w*", RECORD_ID)
+    if not europeana_id:
+        raise ValueError("Not valid RECORD_ID")
+    if not isinstance(PAGE_ID, int):
+        raise ValueError("PAGE_ID must be an int")
+    return requests.get(
+        f"https://iiif.europeana.eu/presentation{RECORD_ID}/annopage/{PAGE_ID}",
+        params={"wskey": wskey},
+    ).json()
+
 
 def fulltext(**kwargs):
-  """
+    """
   Fulltext method of the IIIF API [1]. Returns the transciption of a single page of a newspaper
 
   >>> import pyeuropeana.apis as apis
@@ -139,7 +149,7 @@ def fulltext(**kwargs):
   >>>    RECORD_ID = '/9200356/BibliographicResource_3000118390149',
   >>>    FULLTEXT_ID = '',
   >>> )
-  
+
   Args:
     RECORD_ID (:obj:`str`)
         The identifier of the record which is composed of the dataset identifier \\
@@ -153,19 +163,15 @@ def fulltext(**kwargs):
   References:
     1. https://pro.europeana.eu/page/iiif
   """
-  wskey = get_api_key()
-  RECORD_ID = kwargs.get('RECORD_ID')
-  FULLTEXT_ID = kwargs.get('FULLTEXT_ID')
-  if not kwargs:
-    raise ValueError('No arguments passed')
-  europeana_id = re.findall('/\w*/\w*',RECORD_ID)
-  if not europeana_id:
-    raise ValueError('Not valid RECORD_ID')
-  return requests.get(f'https://www.europeana.eu/api/fulltext{RECORD_ID}/{FULLTEXT_ID}',params = {'wskey':wskey}).json()
-
-
-
-
-
-
-
+    wskey = get_api_key()
+    RECORD_ID = kwargs.get("RECORD_ID")
+    FULLTEXT_ID = kwargs.get("FULLTEXT_ID")
+    if not kwargs:
+        raise ValueError("No arguments passed")
+    europeana_id = re.findall("/\w*/\w*", RECORD_ID)
+    if not europeana_id:
+        raise ValueError("Not valid RECORD_ID")
+    return requests.get(
+        f"https://www.europeana.eu/api/fulltext{RECORD_ID}/{FULLTEXT_ID}",
+        params={"wskey": wskey},
+    ).json()

--- a/src/pyeuropeana/apis/record.py
+++ b/src/pyeuropeana/apis/record.py
@@ -3,13 +3,14 @@ import re
 
 from ..utils.auth import get_api_key
 
+
 def record(record_id):
-  """
+    """
   Wrapper for the Record API [1]. Returns the information of an object specified by the Europeana ID
 
   >>> import pyeuropeana.apis as apis
   >>> resp = apis.record('/79/resource_document_museumboerhaave_V35167')
-  
+
   Args:
     record_id (:obj:`str`)
         The identifier of the record which is composed of the dataset identifier \\
@@ -24,20 +25,21 @@ def record(record_id):
     2. https://pro.europeana.eu/page/intro#identifying-records
   """
 
-  params = {
-    'wskey':get_api_key(),
+    params = {
+        "wskey": get_api_key(),
     }
-  
-  if not isinstance(record_id,str):
-    raise ValueError('the input id should be a string')
 
-  # check regex europeana ID
-  europeana_id = re.findall('/\w*/\w*',record_id)
-  if not europeana_id:
-    raise ValueError('Not valid Europeana id')
+    if not isinstance(record_id, str):
+        raise ValueError("the input id should be a string")
 
-  response = requests.get(f'https://api.europeana.eu/record/v2/{record_id}.json',params=params).json()  
-  if not response['success']:
-    raise ValueError(response['error'])
-  return response
- 
+    # check regex europeana ID
+    europeana_id = re.findall("/\w*/\w*", record_id)
+    if not europeana_id:
+        raise ValueError("Not valid Europeana id")
+
+    response = requests.get(
+        f"https://api.europeana.eu/record/v2/{record_id}.json", params=params
+    ).json()
+    if not response["success"]:
+        raise ValueError(response["error"])
+    return response

--- a/src/pyeuropeana/apis/search.py
+++ b/src/pyeuropeana/apis/search.py
@@ -3,103 +3,104 @@ import requests
 from ..utils.auth import get_api_key
 from ..utils.edm_utils import cursor_search
 
+
 def search(**kwargs):
-  """
-  Wrapper for the Search API [1]. Returns objects matching a query with several parameters
+    """
+    Wrapper for the Search API [1]. Returns objects matching a query with several parameters
 
-  >>> import pyeuropeana.apis as apis
-  >>> resp = apis.search(
-  >>>    query = '*',s
-  >>>    qf = 'TYPE:IMAGE',
-  >>>    reusability = 'open AND permission',
-  >>>    media = True,
-  >>>    thumbnail = True,
-  >>>    colourpalette = '#0000FF',
-  >>>    theme = 'photography',
-  >>>    sort = 'europeana_id',
-  >>>    profile = 'rich',
-  >>>    rows = 1000,
-  >>>     )
+    >>> import pyeuropeana.apis as apis
+    >>> resp = apis.search(
+    >>>    query = '*',s
+    >>>    qf = 'TYPE:IMAGE',
+    >>>    reusability = 'open AND permission',
+    >>>    media = True,
+    >>>    thumbnail = True,
+    >>>    colourpalette = '#0000FF',
+    >>>    theme = 'photography',
+    >>>    sort = 'europeana_id',
+    >>>    profile = 'rich',
+    >>>    rows = 1000,
+    >>>     )
 
-  Args:
-    query (:obj:`str`)
-        The search term(s). See Query Syntax [?] for information on forming complex queries and examples.
-    rows (:obj:`int`,optional)
-      The number of records to return. Maximum is 100. Defaults to 12. See pagination.
-    qf (:obj:`str`,optional)
-        Query Refinement. This parameter can be defined more than once. See Query Syntax [?] page for more information.
-    reusability (:obj:`str`,optional)
-      Filter by copyright status. Possible values are open, restricted or permission.
-    media (:obj:`bool`,optional)
-      Filter by records where an URL to the full media file is present in the edm:isShownBy or edm:hasView metadata and is resolvable.
-    thumbnail (:obj:`bool`,optional)
-      Filter by records where a thumbnail image has been generated for any of the WebResource media resources (thumbnail available in the edmPreview field).
-    landingpage (:obj:`bool`,optional)
-      Filter by records where the link to the original object on the providers website (edm:isShownAt) is present and verified to be working.
-    colourpalette (:obj:`str`,optional)
-      Filter by images where one of the colours (see colour palette) of an image matches the provided colour code. You can provide this parameter multiple times, the search will then do an 'AND' search on all the provided colours.
-    theme (:obj:`str`,optional)
-      Restrict the query over one of the Europeana Thematic Collections. The possible values are: archaelogy, art, fashion, industrial, manuscript, map, migration, music, nature, newspaper, photography, sport, ww1.
-    sort (:obj:`str`,optional)
-      Sorting records in ascending or descending order of search fields. The following fields are supported: score (relenvancy of the search result), timestamp_created, timestamp_update, europeana_id, COMPLETENESS, is_fulltext, has_thumbnails, and has_media. Sorting on more than one field is possible by supplying as comma separated values. It is also possible to randomly order items by using the keyword "random" instead of a field name. You can also request for a fixed random order by indicating a seed "random_SEED" which is useful when paginating along the same randomized order.
-    profile (:obj:`str`,optional)
-      A profile parameter which controls the format and richness of the response.
-    cursor (:obj:`str`,optional)
-      A cursor mark from where to start the search result set when using deep pagination. Set to * to start cursor-based pagination.
-    callback (:obj:`str`,optional)
-      Name of a client side callback function, see JSONP.
-    facet (:obj:`str`,optional)
-      A name of an individual field or a comma separated list of fields
+    Args:
+      query (:obj:`str`)
+          The search term(s). See Query Syntax [?] for information on forming complex queries and examples.
+      rows (:obj:`int`,optional)
+        The number of records to return. Maximum is 100. Defaults to 12. See pagination.
+      qf (:obj:`str`,optional)
+          Query Refinement. This parameter can be defined more than once. See Query Syntax [?] page for more information.
+      reusability (:obj:`str`,optional)
+        Filter by copyright status. Possible values are open, restricted or permission.
+      media (:obj:`bool`,optional)
+        Filter by records where an URL to the full media file is present in the edm:isShownBy or edm:hasView metadata and is resolvable.
+      thumbnail (:obj:`bool`,optional)
+        Filter by records where a thumbnail image has been generated for any of the WebResource media resources (thumbnail available in the edmPreview field).
+      landingpage (:obj:`bool`,optional)
+        Filter by records where the link to the original object on the providers website (edm:isShownAt) is present and verified to be working.
+      colourpalette (:obj:`str`,optional)
+        Filter by images where one of the colours (see colour palette) of an image matches the provided colour code. You can provide this parameter multiple times, the search will then do an 'AND' search on all the provided colours.
+      theme (:obj:`str`,optional)
+        Restrict the query over one of the Europeana Thematic Collections. The possible values are: archaelogy, art, fashion, industrial, manuscript, map, migration, music, nature, newspaper, photography, sport, ww1.
+      sort (:obj:`str`,optional)
+        Sorting records in ascending or descending order of search fields. The following fields are supported: score (relenvancy of the search result), timestamp_created, timestamp_update, europeana_id, COMPLETENESS, is_fulltext, has_thumbnails, and has_media. Sorting on more than one field is possible by supplying as comma separated values. It is also possible to randomly order items by using the keyword "random" instead of a field name. You can also request for a fixed random order by indicating a seed "random_SEED" which is useful when paginating along the same randomized order.
+      profile (:obj:`str`,optional)
+        A profile parameter which controls the format and richness of the response.
+      cursor (:obj:`str`,optional)
+        A cursor mark from where to start the search result set when using deep pagination. Set to * to start cursor-based pagination.
+      callback (:obj:`str`,optional)
+        Name of a client side callback function, see JSONP.
+      facet (:obj:`str`,optional)
+        A name of an individual field or a comma separated list of fields
 
-  Returns: :obj:`dict`
-    Response
+    Returns: :obj:`dict`
+      Response
 
-  References:
-    1. https://pro.europeana.eu/page/search
-
-  
-  """
-  params = {
-      'wskey':get_api_key(),
-      'query':kwargs.get('query','*'), 
-      'qf':kwargs.get('qf'),
-      'reusability':kwargs.get('reusability'),
-      'media':kwargs.get('media'),
-      'thumbnail':kwargs.get('thumbnail'),
-      'landingpage':kwargs.get('landingpage'),
-      'colourpalette':kwargs.get('colourpalette'),
-      'theme':kwargs.get('theme'),
-      'sort':kwargs.get('sort','europeana_id'),
-      'profile':kwargs.get('profile'),
-      'rows':kwargs.get('rows',12),
-      'cursor':kwargs.get('cursor','*'),
-      'callback':kwargs.get('callback'),   
-      'facet':kwargs.get('facet'),
-  }
-
-  endpoint = 'https://api.europeana.eu/record/v2/search.json'
-
-  if not kwargs:
-    raise ValueError('No arguments passed')
-
-  # test key
-  response = requests.get(endpoint, params = {'wskey':params['wskey'],'query':'*'}).json()
-  if not response['success']:
-    raise ValueError(response['error'])
-
-  # Necessary for handling facets of the type 'PROVIDER&f.PROVIDER.facet.limit=30&f.PROVIDER.facet.offset=10'
-  _params = params.copy()
-  if params['facet']:
-    facet_list = params['facet'].split('&')
-    if len(facet_list)>1:
-      _params.update({'facet':facet_list[0]})
-      _params.update({item.split('=')[0]:item.split('=')[1] for item in facet_list[1:]})
-
-  url = requests.get(endpoint, params = _params).url
-  response =  cursor_search(endpoint,_params)
-  response.update({'url':url,'params':params})
-  return response  
- 
+    References:
+      1. https://pro.europeana.eu/page/search
 
 
+    """
+    params = {
+        "wskey": get_api_key(),
+        "query": kwargs.get("query", "*"),
+        "qf": kwargs.get("qf"),
+        "reusability": kwargs.get("reusability"),
+        "media": kwargs.get("media"),
+        "thumbnail": kwargs.get("thumbnail"),
+        "landingpage": kwargs.get("landingpage"),
+        "colourpalette": kwargs.get("colourpalette"),
+        "theme": kwargs.get("theme"),
+        "sort": kwargs.get("sort", "europeana_id"),
+        "profile": kwargs.get("profile"),
+        "rows": kwargs.get("rows", 12),
+        "cursor": kwargs.get("cursor", "*"),
+        "callback": kwargs.get("callback"),
+        "facet": kwargs.get("facet"),
+    }
 
+    endpoint = "https://api.europeana.eu/record/v2/search.json"
+
+    if not kwargs:
+        raise ValueError("No arguments passed")
+
+    # test key
+    response = requests.get(
+        endpoint, params={"wskey": params["wskey"], "query": "*"}
+    ).json()
+    if not response["success"]:
+        raise ValueError(response["error"])
+
+    # Necessary for handling facets of the type 'PROVIDER&f.PROVIDER.facet.limit=30&f.PROVIDER.facet.offset=10'
+    _params = params.copy()
+    if params["facet"]:
+        facet_list = params["facet"].split("&")
+        if len(facet_list) > 1:
+            _params.update({"facet": facet_list[0]})
+            _params.update(
+                {item.split("=")[0]: item.split("=")[1] for item in facet_list[1:]}
+            )
+
+    url = requests.get(endpoint, params=_params).url
+    response = cursor_search(endpoint, _params)
+    response.update({"url": url, "params": params})
+    return response

--- a/src/pyeuropeana/utils/__init__.py
+++ b/src/pyeuropeana/utils/__init__.py
@@ -1,5 +1,10 @@
 from . import edm_utils as edm_utils
 from . import img_utils as img_utils
 
-from .edm_utils import search2df, europeana_id2uri, process_CHO_search, process_CHO_record
+from .edm_utils import (
+    search2df,
+    europeana_id2uri,
+    process_CHO_search,
+    process_CHO_record,
+)
 from .img_utils import url2img

--- a/src/pyeuropeana/utils/auth.py
+++ b/src/pyeuropeana/utils/auth.py
@@ -1,11 +1,12 @@
 import os
 
+
 def get_api_key():
-  API_KEY = os.environ.get('EUROPEANA_API_KEY')
-  if not API_KEY:
-    message = """
+    API_KEY = os.environ.get("EUROPEANA_API_KEY")
+    if not API_KEY:
+        message = """
     EUROPEANA_API_KEY not set. Set EUROPEANA_API_KEY as an environment variable running 'export EUROPEANA_API_KEY=yourapikey' in the terminal.
     If running in Google Colab use os.environ['EUROPEANA_API_KEY'] = 'yourapikey'
     """
-    raise Exception(message)
-  return API_KEY
+        raise Exception(message)
+    return API_KEY

--- a/src/pyeuropeana/utils/edm_utils.py
+++ b/src/pyeuropeana/utils/edm_utils.py
@@ -5,6 +5,7 @@ import requests
 
 from typing import Optional
 
+
 def search2df(response: dict, full: Optional[bool] = False) -> pd.DataFrame:
     """
 
@@ -29,7 +30,7 @@ def search2df(response: dict, full: Optional[bool] = False) -> pd.DataFrame:
       Dataframe with columns ...
 
     """
-    CHO_list = response['items']
+    CHO_list = response["items"]
     if not CHO_list:
         return None
     if full:
@@ -38,101 +39,112 @@ def search2df(response: dict, full: Optional[bool] = False) -> pd.DataFrame:
     return pd.DataFrame(CHO_list)
 
 
-def cursor_search(endpoint,params):
-  """
-  Cursor search function
-  """
-  CHO_list = []
-  response = {'nextCursor':params['cursor']}
-  while 'nextCursor' in response:
-    if len(CHO_list)>params['rows']:
-      break
-    params.update({'cursor':response['nextCursor']})
-    response = requests.get(endpoint, params = params).json()
-    CHO_list += response['items']
-  CHO_list = CHO_list[:params['rows']]
-  response['items'] = CHO_list
-  return response
+def cursor_search(endpoint, params):
+    """
+    Cursor search function
+    """
+    CHO_list = []
+    response = {"nextCursor": params["cursor"]}
+    while "nextCursor" in response:
+        if len(CHO_list) > params["rows"]:
+            break
+        params.update({"cursor": response["nextCursor"]})
+        response = requests.get(endpoint, params=params).json()
+        CHO_list += response["items"]
+    CHO_list = CHO_list[: params["rows"]]
+    response["items"] = CHO_list
+    return response
 
 
 def europeana_id2uri(ID):
-  return 'http://data.europeana.eu/item'+ID
-
-
+    return "http://data.europeana.eu/item" + ID
 
 
 def process_CHO_search(item):
-  europeana_id = item['id'] if 'id' in item.keys() else None
-  return {
-      #'raw_metadata': item,
-      'europeana_id': europeana_id,
-      'uri': europeana_id2uri(europeana_id),
-      'type': item['type'] if 'type' in item.keys() else None,
-      'image_url': item['edmIsShownBy'][0] if 'edmIsShownBy' in item.keys() else None,
-      'country': item['country'][0] if 'country' in item.keys() else None,
-      'description': item['dcDescription'][0] if 'dcDescription' in item.keys() else None,
-      'title': item['title'][0] if 'title' in item.keys() else None,
-      'creator': item['dcCreator'][0] if 'dcCreator' in item.keys() else None,
-      'language': item['language'][0] if 'language' in item.keys() else None,
-      'rights': item['rights'][0] if 'rights' in item.keys() else None,
-      'provider': item['dataProvider'][0] if 'dataProvider' in item.keys() else None,
-      'dataset_name': item['edmDatasetName'][0] if 'edmDatasetName' in item.keys() else None,
-      'concept': item['edmConcept'][0] if 'edmConcept' in item.keys() else None,
-      'concept_lang': {k:v[0] for k,v in item['edmConceptPrefLabelLangAware'].items()} if 'edmConceptPrefLabelLangAware' in item.keys() else None,
-      'description_lang': {k:v[0] for k,v in item['dcDescriptionLangAware'].items()} if 'dcDescriptionLangAware' in item.keys() else None,
-      'title_lang': {k:v[0] for k,v in item['dcTitleLangAware'].items()} if 'dcTitleLangAware' in item.keys() else None, 
-  }
+    europeana_id = item["id"] if "id" in item.keys() else None
+    return {
+        # 'raw_metadata': item,
+        "europeana_id": europeana_id,
+        "uri": europeana_id2uri(europeana_id),
+        "type": item["type"] if "type" in item.keys() else None,
+        "image_url": item["edmIsShownBy"][0] if "edmIsShownBy" in item.keys() else None,
+        "country": item["country"][0] if "country" in item.keys() else None,
+        "description": item["dcDescription"][0]
+        if "dcDescription" in item.keys()
+        else None,
+        "title": item["title"][0] if "title" in item.keys() else None,
+        "creator": item["dcCreator"][0] if "dcCreator" in item.keys() else None,
+        "language": item["language"][0] if "language" in item.keys() else None,
+        "rights": item["rights"][0] if "rights" in item.keys() else None,
+        "provider": item["dataProvider"][0] if "dataProvider" in item.keys() else None,
+        "dataset_name": item["edmDatasetName"][0]
+        if "edmDatasetName" in item.keys()
+        else None,
+        "concept": item["edmConcept"][0] if "edmConcept" in item.keys() else None,
+        "concept_lang": {
+            k: v[0] for k, v in item["edmConceptPrefLabelLangAware"].items()
+        }
+        if "edmConceptPrefLabelLangAware" in item.keys()
+        else None,
+        "description_lang": {k: v[0] for k, v in item["dcDescriptionLangAware"].items()}
+        if "dcDescriptionLangAware" in item.keys()
+        else None,
+        "title_lang": {k: v[0] for k, v in item["dcTitleLangAware"].items()}
+        if "dcTitleLangAware" in item.keys()
+        else None,
+    }
+
 
 def process_CHO_record(response):
-    obj = response['object']
-    europeana_id = obj['about']
+    obj = response["object"]
+    europeana_id = obj["about"]
 
     try:
-      image_url = obj['aggregations'][0]['edmIsShownBy']
-    except:
-      image_url = None
+        image_url = obj["aggregations"][0]["edmIsShownBy"]
+    except Exception:
+        image_url = None
 
     # getting title
-    proxy_list = obj['proxies']
+    proxy_list = obj["proxies"]
     proxy_dict = {}
     for proxy in proxy_list:
-      proxy_dict.update(proxy)
+        proxy_dict.update(proxy)
 
-    title_lang = proxy_dict['dcTitle'] if 'dcTitle' in proxy_dict else None
+    title_lang = proxy_dict["dcTitle"] if "dcTitle" in proxy_dict else None
     title = None
     if title_lang:
-      title_lang = {k:v[0] for k,v in title_lang.items()}
-      title = get_value_lang(title_lang)
-      
+        title_lang = {k: v[0] for k, v in title_lang.items()}
+        title = get_value_lang(title_lang)
+
     # getting provider
-    provider_lang = obj['aggregations'][0]['edmProvider']
-    provider_lang = {k:v[0] for k,v in provider_lang.items()}
+    provider_lang = obj["aggregations"][0]["edmProvider"]
+    provider_lang = {k: v[0] for k, v in provider_lang.items()}
     provider = get_value_lang(provider_lang)
 
     return {
-        #'raw_metadata': response,
-        'europeana_id': europeana_id,
-        'image_url': image_url,
-        'uri': europeana_id2uri(europeana_id),
-        'dataset_name': obj['edmDatasetName'][0],
-        'country': obj['europeanaAggregation']['edmCountry']['def'][0],
-        'language': obj['europeanaAggregation']['edmLanguage']['def'][0],
-        'type': obj['type'],
-        'title': title,
-        'title_lang': title_lang,
-        'rights': obj['aggregations'][0]['edmRights']['def'][0],
-        'provider': provider,
-        'provider_lang': provider_lang,
+        # 'raw_metadata': response,
+        "europeana_id": europeana_id,
+        "image_url": image_url,
+        "uri": europeana_id2uri(europeana_id),
+        "dataset_name": obj["edmDatasetName"][0],
+        "country": obj["europeanaAggregation"]["edmCountry"]["def"][0],
+        "language": obj["europeanaAggregation"]["edmLanguage"]["def"][0],
+        "type": obj["type"],
+        "title": title,
+        "title_lang": title_lang,
+        "rights": obj["aggregations"][0]["edmRights"]["def"][0],
+        "provider": provider,
+        "provider_lang": provider_lang,
     }
 
 
 def europeana_id2filename(europeana_id):
-  return europeana_id.replace("/","[ph]")+'.jpg'
+    return europeana_id.replace("/", "[ph]") + ".jpg"
+
 
 def get_value_lang(lang_dict):
-    if 'en' in lang_dict.keys():
-      value = lang_dict['en']
+    if "en" in lang_dict.keys():
+        value = lang_dict["en"]
     else:
-      _ , value = list(lang_dict.items())[0]
+        _, value = list(lang_dict.items())[0]
     return value
-

--- a/src/pyeuropeana/utils/img_utils.py
+++ b/src/pyeuropeana/utils/img_utils.py
@@ -6,7 +6,8 @@ import pandas as pd
 from PIL import Image
 from pyeuropeana.utils.edm_utils import europeana_id2filename
 
-def url2img(url,time_limit = 10):
+
+def url2img(url, time_limit=10):
 
     """
     Utility for obtaining a PIL Image object from an image url
@@ -33,23 +34,20 @@ def url2img(url,time_limit = 10):
 
     """
 
-    def worker(image_url,data_dict):
+    def worker(image_url, data_dict):
         try:
-            data_dict['image']  = Image.open(urllibrec.urlopen(image_url)).convert('RGB')
-        except:
-            data_dict['image']  = None
+            data_dict["image"] = Image.open(urllibrec.urlopen(image_url)).convert("RGB")
+        except Exception:
+            data_dict["image"] = None
 
     manager = Manager()
     data_dict = manager.dict()
 
-    action_process = Process(target=worker,args=(url,data_dict))
+    action_process = Process(target=worker, args=(url, data_dict))
     action_process.start()
-    action_process.join(timeout=time_limit) 
+    action_process.join(timeout=time_limit)
     action_process.terminate()
-    if 'image' in data_dict.keys():
-        return data_dict['image']
+    if "image" in data_dict.keys():
+        return data_dict["image"]
     else:
         return None
-
-
-

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -2,19 +2,19 @@ import unittest
 
 import pyeuropeana.apis as apis
 
-class TestEntity(unittest.TestCase):
 
+class TestEntity(unittest.TestCase):
     def test_suggest(self):
         """
         Test that at least one argument is being passed
         """
         with self.assertRaises(ValueError) as context:
             apis.entity.suggest()
-        self.assertTrue('No arguments passed' in str(context.exception))
+        self.assertTrue("No arguments passed" in str(context.exception))
 
         with self.assertRaises(ValueError) as context:
             apis.entity.suggest(
-                TYPE = 'agent',
+                TYPE="agent",
             )
         self.assertTrue('Argument "text" is needed' in str(context.exception))
 
@@ -24,16 +24,13 @@ class TestEntity(unittest.TestCase):
         """
         with self.assertRaises(ValueError) as context:
             apis.entity.retrieve()
-        self.assertTrue('No arguments passed' in str(context.exception))
-        
+        self.assertTrue("No arguments passed" in str(context.exception))
+
     def test_resolve(self):
         with self.assertRaises(ValueError) as context:
             apis.entity.resolve(2)
-        self.assertTrue('input uri must be a string' in str(context.exception))
+        self.assertTrue("input uri must be a string" in str(context.exception))
 
 
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()
-
-

--- a/tests/test_iiif.py
+++ b/tests/test_iiif.py
@@ -5,35 +5,22 @@ import pyeuropeana.apis as apis
 if __name__ == "__main__":
 
     # IIIF
-    apis.iiif.manifest('/9200356/BibliographicResource_3000118390149')
+    apis.iiif.manifest("/9200356/BibliographicResource_3000118390149")
     apis.iiif.annopage(
-    RECORD_ID = '/9200356/BibliographicResource_3000118390149',
-    PAGE_ID = 1
+        RECORD_ID="/9200356/BibliographicResource_3000118390149", PAGE_ID=1
     )
     apis.iiif.fulltext(
-    RECORD_ID = '/9200396/BibliographicResource_3000118435063',
-    FULLTEXT_ID = '8ebb67ccf9f8a1dcc2ea119c60954111'
+        RECORD_ID="/9200396/BibliographicResource_3000118435063",
+        FULLTEXT_ID="8ebb67ccf9f8a1dcc2ea119c60954111",
     )
 
-    resp = apis.iiif.search(
-    query = 'leonardo',
-    profile = 'hits',
-    rows = 250
-    )
+    resp = apis.iiif.search(query="leonardo", profile="hits", rows=250)
 
-    print(len(resp['items']))
+    print(len(resp["items"]))
 
-    resp = apis.iiif.search(
-    query = 'leonardo',
-    profile = 'hits&hit.selectors=5',
-    rows = 250
-    )
+    resp = apis.iiif.search(query="leonardo", profile="hits&hit.selectors=5", rows=250)
 
-    print(resp['hits'])
-
-
-
-
+    print(resp["hits"])
 
     # result = apis.search(
     #     query = '*',

--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -2,8 +2,8 @@ import unittest
 
 from pyeuropeana.apis import record
 
-class TestRecord(unittest.TestCase):
 
+class TestRecord(unittest.TestCase):
     def test_input_id(self):
         """
         Test valid id
@@ -13,24 +13,21 @@ class TestRecord(unittest.TestCase):
         self.assertTrue("the input id should be a string" in str(context.exception))
 
         with self.assertRaises(ValueError) as context:
-          record(True)
+            record(True)
         self.assertTrue("the input id should be a string" in str(context.exception))
 
         with self.assertRaises(ValueError) as context:
-          record('asfd')
+            record("asfd")
         self.assertTrue("Not valid Europeana id" in str(context.exception))
 
         with self.assertRaises(ValueError) as context:
-            record('/asdfa345sdf')
+            record("/asdfa345sdf")
         self.assertTrue("Not valid Europeana id" in str(context.exception))
 
         with self.assertRaises(ValueError) as context:
-            record('asdfa/345sdf')
+            record("asdfa/345sdf")
         self.assertTrue("Not valid Europeana id" in str(context.exception))
 
 
 if __name__ == "__main__":
     unittest.main()
-
-
-

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -2,28 +2,17 @@ import unittest
 
 from pyeuropeana.apis import search
 
-class TestSearch(unittest.TestCase):
 
+class TestSearch(unittest.TestCase):
     def test_args(self):
-        
+
         # Test that at least one argument is being passed
-       
+
         with self.assertRaises(ValueError) as context:
             search()
-        self.assertTrue('No arguments passed' in str(context.exception))
-
-        
+        self.assertTrue("No arguments passed" in str(context.exception))
 
 
 if __name__ == "__main__":
-    #unittest.main()
-
-    
-
-
-
-    
-
-
-
-   
+    # unittest.main()
+    pass


### PR DESCRIPTION
# Summary

Pre-commit is now specified as a dev dependency in `pyproject.toml`. Through Pre-commit, we have access to black (code formatter) and flake8 (code linter.). These pseudo-dependencies are not specified directly in `pyproject.toml` and thus are not explicitly installed. Instead they are accessed every time through their Git repos in a quick and efficient manner.

flake8 and black is set to work on files only inside the `src/` folder and the `tests/` folder. Additional configurations can be found under `pyproject.toml` "black" section, the `.flake8` file and in `pre-commit-config.yaml`.

This pull request also features a major code style overhaul: .py file under `src/` and `tests/` were formatted using black and checked with flake8.

# Following work
This pull request will be followed by:
- An additional pull request fleshing out the `CONTRIBUTING.md` file as discussed in #11  
- A GitHub Action that runs flake8 on each pull request to enforce code styleguide compliance.


**IMPORTANT NOTE**: This pull request was tested using the color palette extraction notebook and it all seemed clear. However, since there were changes to the .py files under `src/`, we should be wary for a while. If anything breaks right after this pull request, this pull request is most likely the culprit.