### PR TITLE
Feature flake8 ghub action

### DIFF
--- a/.github/workflows/style-check.yaml
+++ b/.github/workflows/style-check.yaml
@@ -1,0 +1,18 @@
+name: stylecheck
+on:
+  pull_request:
+    branches:
+      - master
+  paths:
+    - 'src/**'
+    - 'tests/**'
+jobs:
+  flake8-linting:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3 # make pull request repo available inside the vm
+      - uses: actions/setup-python#v3 # vm already has python, but I want a specific version
+        with:
+          python-version: '^3.7'
+      - run: python -m pip install flake8
+      - run: flake8

--- a/.github/workflows/style-check.yaml
+++ b/.github/workflows/style-check.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3 # make pull request repo available inside the vm
-      - uses: actions/setup-python#v3 # vm already has python, but I want a specific version
+      - uses: actions/setup-python@v3 # vm already has python, but I want a specific version
         with:
           python-version: '^3.7'
       - run: python -m pip install flake8

--- a/.github/workflows/style-check.yaml
+++ b/.github/workflows/style-check.yaml
@@ -3,9 +3,9 @@ on:
   pull_request:
     branches:
       - master
-  paths:
-    - 'src/**'
-    - 'tests/**'
+    paths:
+      - 'src/**'
+      - 'tests/**'
 jobs:
   flake8-linting:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

We now have a folder titled `.github/` that houses our CI/CD workflows.  Currently the only workflow that we have there is `style-check.yaml`. This workflow is set to run flake8 on the changed parts of the codebase (`src/*` and `tests/*`) every time a pull request to master concerning the changed parts is made. Although flake8 is the only code style tool we use right now, the workflow can be expanded with more jobs later on. Other CI/CD workflows will also live under `.github/`.

Discussion regarding the CI/CD pipelines we want to implement can be found at #17.