### PR TITLE
Removed requirements.txt from project root.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,0 @@
-schema
-requests
-pillow
-pandas
-numpy
-matplotlib
-sphinx-gallery
-nbsphinx


### PR DESCRIPTION
## Summary

The `requirements.txt` located in the root of the project was an artifact from the time we did not have `pyproject.toml`.